### PR TITLE
Add dynamic routing 'widget'

### DIFF
--- a/src/Reflex/Dom/Contrib/Router.hs
+++ b/src/Reflex/Dom/Contrib/Router.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts         #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE JavaScriptFFI            #-}
+{-# LANGUAGE OverloadedStrings        #-}
 {-# LANGUAGE RankNTypes               #-}
 {-# LANGUAGE RecursiveDo              #-}
 {-# LANGUAGE ScopedTypeVariables      #-}
@@ -12,88 +13,103 @@
 module Reflex.Dom.Contrib.Router where
 
 ------------------------------------------------------------------------------
-import           Control.Monad
-import           Control.Monad.Trans
-import           Data.Text (Text)
-import qualified Data.Text as T
-import           GHCJS.DOM
-import           GHCJS.DOM.Document hiding (error)
-import           GHCJS.DOM.Types (unWindow)
-import           GHCJS.DOM.Window hiding (error)
-import           GHCJS.DOM.HTMLDocument
-#ifdef ghcjs_HOST_OS
-import GHCJS.Foreign.Callback
-import           GHCJS.Types
-import           GHCJS.Prim
-#endif
-import           Prelude hiding (mapM, mapM_, all, sequence)
-import           Reflex.Dom hiding (Window, fromJSString)
-import           Reflex.Dom.Contrib.Utils
-------------------------------------------------------------------------------
-
-
-------------------------------------------------------------------------------
-setUrl
-    :: MonadWidget t m
-    => Event t String
-    -> m ()
-setUrl e = do
-    performEvent_ $ ffor e $ \url -> liftIO $ do
-        windowHistoryPushState url
-
-
-------------------------------------------------------------------------------
-getWindowLocation :: Window -> IO String
-#ifdef ghcjs_HOST_OS
-getWindowLocation w = do
-    liftM fromJSString $ js_windowLocationPathname (unWindow w)
-
-foreign import javascript unsafe
-  "$1['location']['pathname']"
-  js_windowLocationPathname :: JSVal -> IO JSVal
+import           Control.Monad.IO.Class    (MonadIO, liftIO)
+import           Data.Maybe                (fromJust)
+import qualified Data.Text                 as T
+import           Reflex.Dom                hiding (Window)
+#if ghcjs_HOST_OS
+import           GHCJS.DOM.History         (back, forward, pushState)
+import           GHCJS.DOM.Window          (getLocation, popState)
+import           GHCJS.DOM.Location        (toString)
+import           GHCJS.DOM.Window          (Window, getHistory)
+import           GHCJS.Marshal.Pure
+import qualified GHCJS.DOM                 as DOM
+import qualified GHCJS.DOM.Document        as DOM
+import qualified GHCJS.DOM.EventM          as DOM
 #else
-getWindowLocation =
-    error "getWindowLocation: only works in GHCJS"
+-- import Graphics.UI.Gtk.Types.Document
 #endif
 
-
 ------------------------------------------------------------------------------
-setupHistoryHandler :: Window -> (String -> IO ()) -> IO ()
-#ifdef ghcjs_HOST_OS
-setupHistoryHandler w cb = do
-    cbRef <- syncCallback1 ThrowWouldBlock (cb . fromJSString)
-    js_setupHistoryHandler (unWindow w) cbRef
+data RouteConfig t = RouteConfig
+  { _routeConfig_forward   :: Event t () -- ^ Move the browser history forward
+  , _routeConfig_back      :: Event t () -- ^ Move the browser history back
+  , _routeConfig_pushState :: Event t T.Text -- ^ Push to the URL state
+  -- , _routeConfig_pathBase  :: T.Text
+  --   -- ^ The part of the URL not related to SPA routing
+  }
 
-foreign import javascript unsafe
-  "$1.onpopstate = function(event) { $2($1['location']['pathname']); }"
-  js_setupHistoryHandler :: JSVal -> Callback (JSVal -> IO ()) -> IO ()
+data Route t = Route {
+    _route_value :: Dynamic t T.Text -- ^ URL value
+  }
+
+-- | Manipulate and track the URL text for dynamic routing of a widget
+route :: (HasWebView m, MonadWidget t m) => RouteConfig t -> m (Route t)
+route (RouteConfig goForward goBack sSet) = do
+  win <- askDomWindow
+  loc <- getLocation' win
+  Just hist <- liftIO $ getHistory win
+  performEvent_ $ ffor goForward $ \_ -> liftIO (forward hist)
+  performEvent_ $ ffor goBack    $ \_ -> liftIO (back hist)
+  setLoc <- performEvent $ ffor sSet $ \t -> do
+    pushState hist (pToJSVal (0 :: Int)) ("" :: T.Text) t
+    getLocation' win
+  newLocs <- getPopState
+  Route <$> holdDyn loc (leftmost [setLoc, newLocs])
+
+-- | Get the DOM window object.
+askDomWindow :: (HasWebView m, MonadIO m) => m Window
+askDomWindow = do
+  wv <- askWebView
+  Just doc <- liftIO . DOM.webViewGetDomDocument $ unWebViewSingleton wv
+  Just window <- liftIO $ DOM.getDefaultView doc
+  return window
+
+getLocation' :: MonadIO m => Window -> m T.Text
+getLocation' w = toString . fromJust =<< liftIO (getLocation w)
+
+getPopState :: (MonadWidget t m) => m (Event t T.Text)
+getPopState = do
+  window <- askDomWindow
+  wrapDomEventMaybe window (`DOM.on` popState) $ do
+    l <- getLocation window
+    case l of
+      Nothing -> return Nothing
+      Just loc -> do t <- toString loc; return (Just t)
+
+
+#if ghcjs_HOST_OS
 #else
-setupHistoryHandler =
-    error "setupHistoryHandler: only works in GHCJS"
+data Location
+data Window
+data JSVal
+data History
+
+data SerializedScriptValue =
+  SerializedScriptValue { unSerializedScriptValue :: JSVal }
+
+forward :: History -> IO ()
+forward = undefined
+
+back :: History -> IO ()
+back = undefined
+
+class FromJSVal a where
+  fromJSVal :: JSVal -> IO (Maybe a)
+
+getLocation :: Window -> IO (Maybe Location)
+getLocation = undefined
+
+getHistory :: Window -> IO (Maybe History)
+getHistory = undefined
+
+getState :: History -> IO (Maybe SerializedScriptValue)
+getState = undefined
+
+toString :: Location -> IO T.Text
+toString = undefined
+
+getDefaultView = undefined
+
+pushState = undefined
 #endif
-
-
-------------------------------------------------------------------------------
--- | Handles routing for a site.  The argument to this function is a widget
--- function with the effective type signature `String -> m (Event t String)`.
--- The String parameter is the initial value of the window location pathname.
--- The return value is an event that updates the window location.
-routeSite
-    :: (forall t m. MonadWidget t m => Text -> m (Event t Text))
-    -> IO ()
-routeSite siteFunc = runWebGUI $ \webView -> do
-    w <- waitUntilJust currentWindow
-    path <- getWindowLocation w
-    --setupHistoryHandler w (\arg -> putStrLn $ "ghcjs history handling!  " ++ arg)
-    --wrapDomEvent w domWindowOnpopstate myGetEvent
-    doc <- waitUntilJust $ liftM (fmap castToHTMLDocument) $
-             webViewGetDomDocument webView
-    body <- waitUntilJust $ getBody doc
-    attachWidget body (WebViewSingleton webView) $ do
-      changes <- siteFunc (T.pack path)
-      setUrl $ T.unpack <$> changes
-      return ()
-
---myGetEvent = do
---    e <- event
---    liftIO $ uiEventGetView e


### PR DESCRIPTION
This is a small proof of concept for SPA routing without reloads. Thanks @cgibbard for the code samples and @fresheyeball @mightybyte for the discussion.

Some ideas for later improvement:

 - Uncomment and use the `pathBase` field
 - Investigate whether this continues working if you use more than one of them in in a page
 - Write `class ToUrl a` and `class FromUrl a` and generic instances. We would like to have the page router return `(From/ToUrl a, Generic a) => Dynamic t a`. 
 - Make use of the history payload data and page-title-setting arguments in `pushState`