### PR TITLE
Update webroutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.5.1
+
+* Add Monoid instance for RouteConfig
+
+# 0.5
+
+* Add Route, webRoute, textRoute
+
 # 0.4.2
 
 * Add DynamicList widget

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,6 @@
-# 0.5.1
-
-* Add Monoid instance for RouteConfig
-
 # 0.5
 
-* Add Route, webRoute, textRoute
+* Add route, fullUriRoute, partialPathRoute
 
 # 0.4.2
 

--- a/default.nix
+++ b/default.nix
@@ -22,12 +22,11 @@
 , transformers
 , uri-bytestring
 , webkitgtk3-javascriptcore
-, web-routes
 }:
 
 mkDerivation {
   pname = "reflex-dom-contrib";
-  version = "0.5.1";
+  version = "0.5";
   src = builtins.filterSource (path: type: baseNameOf path != ".git") ./.;
   buildDepends = [
     aeson
@@ -51,7 +50,6 @@ mkDerivation {
     time
     transformers
     uri-bytestring
-    web-routes
   ];
   license = null;
 }

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,6 @@
 { mkDerivation
 , aeson
+, base64-bytestring
 , bifunctors
 , data-default
 , ghc
@@ -19,15 +20,18 @@
 , these
 , time
 , transformers
+, uri-bytestring
 , webkitgtk3-javascriptcore
+, web-routes
 }:
 
 mkDerivation {
   pname = "reflex-dom-contrib";
-  version = "0.4";
+  version = "0.5.1";
   src = builtins.filterSource (path: type: baseNameOf path != ".git") ./.;
   buildDepends = [
     aeson
+    base64-bytestring
     bifunctors
     data-default
     ghcjs-base
@@ -46,6 +50,8 @@ mkDerivation {
     these
     time
     transformers
+    uri-bytestring
+    web-routes
   ];
   license = null;
 }

--- a/reflex-dom-contrib.cabal
+++ b/reflex-dom-contrib.cabal
@@ -1,5 +1,5 @@
 name:                reflex-dom-contrib
-version:             0.5
+version:             0.5.1
 synopsis:            A place to experiment with infrastructure and common code for reflex applications
 description:         This library is intended to be a public playground for
                      developing infrastructure, higher level APIs, and widget
@@ -50,25 +50,28 @@ library
      Reflex.Dom.Contrib.Geoposition
 
   build-depends:
-    aeson        >= 0.8  && < 1.1,
-    base         >= 4.6  && < 4.10,
-    bifunctors   >= 4.0  && < 5.5,
-    bytestring   >= 0.10 && < 0.11,
-    containers   >= 0.5  && < 0.6,
-    data-default >= 0.5  && < 0.8,
-    ghcjs-dom    >= 0.2  && < 0.3,
-    http-types   >= 0.8  && < 0.10,
-    lens         >= 4.9  && < 4.15,
-    mtl          >= 2.0  && < 2.3,
-    random       >= 1.0  && < 1.2,
-    readable     >= 0.3  && < 0.4,
-    reflex       >= 0.5  && < 0.6,
-    reflex-dom   >= 0.4  && < 0.5,
-    safe         >= 0.3  && < 0.4,
-    string-conv  >= 0.1  && < 0.2,
-    text         >= 1.2  && < 1.3,
-    time         >= 1.5  && < 1.7,
-    transformers >= 0.4  && < 0.6
+    aeson        >= 0.8    && < 1.1,
+    base         >= 4.6    && < 4.10,
+    bifunctors   >= 4.0    && < 5.5,
+    bytestring   >= 0.10   && < 0.11,
+    base64-bytestring >= 1.0 && < 1.1,
+    containers   >= 0.5    && < 0.6,
+    data-default >= 0.5    && < 0.8,
+    ghcjs-dom    >= 0.2    && < 0.3,
+    http-types   >= 0.8    && < 0.10,
+    lens         >= 4.9    && < 4.15,
+    mtl          >= 2.0    && < 2.3,
+    random       >= 1.0    && < 1.2,
+    readable     >= 0.3    && < 0.4,
+    reflex       >= 0.5    && < 0.6,
+    reflex-dom   >= 0.4    && < 0.5,
+    safe         >= 0.3    && < 0.4,
+    string-conv  >= 0.1    && < 0.2,
+    text         >= 1.2    && < 1.3,
+    time         >= 1.5    && < 1.7,
+    transformers >= 0.4    && < 0.6,
+    uri-bytestring >= 0.2 && < 0.3,
+    web-routes   >= 0.27.1 && < 0.28
 
   if impl(ghcjs)
     build-depends:

--- a/reflex-dom-contrib.cabal
+++ b/reflex-dom-contrib.cabal
@@ -1,5 +1,5 @@
 name:                reflex-dom-contrib
-version:             0.5.1
+version:             0.5
 synopsis:            A place to experiment with infrastructure and common code for reflex applications
 description:         This library is intended to be a public playground for
                      developing infrastructure, higher level APIs, and widget
@@ -50,32 +50,31 @@ library
      Reflex.Dom.Contrib.Geoposition
 
   build-depends:
-    aeson        >= 0.8    && < 1.1,
-    base         >= 4.6    && < 4.10,
-    bifunctors   >= 4.0    && < 5.5,
-    bytestring   >= 0.10   && < 0.11,
-    base64-bytestring >= 1.0 && < 1.1,
-    containers   >= 0.5    && < 0.6,
-    data-default >= 0.5    && < 0.8,
-    ghcjs-dom    >= 0.2    && < 0.3,
-    http-types   >= 0.8    && < 0.10,
-    lens         >= 4.9    && < 4.15,
-    mtl          >= 2.0    && < 2.3,
-    random       >= 1.0    && < 1.2,
-    readable     >= 0.3    && < 0.4,
-    reflex       >= 0.5    && < 0.6,
-    reflex-dom   >= 0.4    && < 0.5,
-    safe         >= 0.3    && < 0.4,
-    string-conv  >= 0.1    && < 0.2,
-    text         >= 1.2    && < 1.3,
-    time         >= 1.5    && < 1.7,
-    transformers >= 0.4    && < 0.6,
-    uri-bytestring >= 0.2 && < 0.3,
-    web-routes   >= 0.27.1 && < 0.28
+    aeson             >= 0.8  && < 1.1,
+    base              >= 4.6  && < 4.10,
+    bifunctors        >= 4.0  && < 5.5,
+    bytestring        >= 0.10 && < 0.11,
+    base64-bytestring >= 1.0  && < 1.1,
+    containers        >= 0.5  && < 0.6,
+    data-default      >= 0.5  && < 0.8,
+    ghcjs-dom         >= 0.2  && < 0.3,
+    http-types        >= 0.8  && < 0.10,
+    lens              >= 4.9  && < 4.15,
+    mtl               >= 2.0  && < 2.3,
+    random            >= 1.0  && < 1.2,
+    readable          >= 0.3  && < 0.4,
+    reflex            >= 0.5  && < 0.6,
+    reflex-dom        >= 0.4  && < 0.5,
+    safe              >= 0.3  && < 0.4,
+    string-conv       >= 0.1  && < 0.2,
+    text              >= 1.2  && < 1.3,
+    time              >= 1.5  && < 1.7,
+    transformers      >= 0.4  && < 0.6,
+    uri-bytestring    >= 0.2  && < 0.3,
 
   if impl(ghcjs)
     build-depends:
-                  ghcjs-base   >= 0.2  && < 0.3,
+                  ghcjs-base >= 0.2 && < 0.3,
                   ghcjs-prim >= 0.1 && < 0.2
 
   default-language:    Haskell2010

--- a/reflex-dom-contrib.cabal
+++ b/reflex-dom-contrib.cabal
@@ -70,7 +70,7 @@ library
     text              >= 1.2  && < 1.3,
     time              >= 1.5  && < 1.7,
     transformers      >= 0.4  && < 0.6,
-    uri-bytestring    >= 0.2  && < 0.3,
+    uri-bytestring    >= 0.2  && < 0.3
 
   if impl(ghcjs)
     build-depends:

--- a/src/Reflex/Dom/Contrib/Router.hs
+++ b/src/Reflex/Dom/Contrib/Router.hs
@@ -13,8 +13,7 @@
 
 module Reflex.Dom.Contrib.Router (
   -- == High-level routers
-    webRoute
-  , partialPathRoute
+    partialPathRoute
   , fullUriRoute
   , route
 
@@ -82,7 +81,10 @@ instance Reflex t => Monoid (RouteConfig t a) where
   mempty = def
   mappend (RouteConfig f1 b1 p1) (RouteConfig f2 b2 p2) =
     RouteConfig (mappend f1 f2) (mappend b1 b2) (leftmost [p1, p2])
-
+  mconcat rcs =
+    RouteConfig (mconcat $ map _routeConfig_forward rcs)
+                (mconcat $ map _routeConfig_back rcs)
+                (leftmost $ map _routeConfig_pushState rcs)
 
 data Route t a = Route {
     _route_value   :: Dynamic t (Either T.Text a)     -- ^ Routing value

--- a/src/Reflex/Dom/Contrib/Router.hs
+++ b/src/Reflex/Dom/Contrib/Router.hs
@@ -13,50 +13,42 @@
 
 module Reflex.Dom.Contrib.Router (
   -- == High-level routers
-    partialPathRoute
-  , fullUriRoute
-  , route
-
-  -- == Router configuration
-  , RouteConfig(..)
-
-  -- == Routing result
-  , Route(..)
-
-  , uriOrigin
-
-  -- == Lenses
-  , routeConfig_forward
-  , routeConfig_back
-  , routeConfig_pushState
-  , route_value
-  , route_fullURI
+    route
+  , route'
+  , partialPathRoute
 
   -- = Low-level URL bar access
-  , getLocation'
-  , getUrlText'
+  , getLoc
+  , getUrlText
+  , uriOrigin
+
+  -- = History movement
+  , goForward
+  , goBack
   ) where
 
 ------------------------------------------------------------------------------
-import           Control.Lens              (makeLenses)
-import           Control.Monad.Except      (ExceptT(..), lift, runExceptT)
+import           Control.Lens              ((&), (.~), (^.))
+-- import           Control.Monad             ((<=<))
+-- import           Control.Monad.Except      (ExceptT(..), lift, runExceptT)
 import           Control.Monad.IO.Class    (MonadIO, liftIO)
-import           Data.Bifunctor            (first)
-import           Data.Maybe                (fromMaybe)
+-- import           Data.Bifunctor            (first)
+import qualified Data.ByteString.Char8     as BS
+-- import           Data.Maybe                (fromJust, fromMaybe)
+import qualified Data.List                 as L
 import           Data.Monoid               ((<>))
-import           Data.Default
+-- import           Data.Default
 import qualified Data.Text                 as T
 import qualified Data.Text.Encoding        as T
 import           GHCJS.DOM.Types           (Location(..) )
 import           Reflex.Dom                hiding (EventName, Window)
 import qualified URI.ByteString            as U
-import qualified Web.Routes.PathInfo       as WR
 #if ghcjs_HOST_OS
 import qualified GHCJS.DOM                 as DOM
 import qualified GHCJS.DOM.Document        as DOM
 import           GHCJS.DOM.EventM          (on)
-import           GHCJS.DOM.History         (back, forward, pushState)
-import           GHCJS.DOM.Location        (getPathname, toString)
+import           GHCJS.DOM.History         (History, back, forward, pushState)
+import           GHCJS.DOM.Location        (toString)
 import           GHCJS.DOM.Window          (Window, getHistory,
                                             getLocation, popState)
 import           GHCJS.Marshal.Pure
@@ -64,125 +56,77 @@ import           GHCJS.Marshal.Pure
 import           Control.Monad.Reader      (ReaderT)
 #endif
 
-------------------------------------------------------------------------------
-data RouteConfig t a = RouteConfig
-  { _routeConfig_forward   :: Event t () -- ^ Move the browser history forward
-  , _routeConfig_back      :: Event t () -- ^ Move the browser history back
-  , _routeConfig_pushState :: Event t a  -- ^ Push to the URL state
-  }
 
-makeLenses ''RouteConfig
+type URI = U.URIRef U.Absolute
 
-instance Reflex t => Default (RouteConfig t a) where
-  def = RouteConfig never never never
-
-
-instance Reflex t => Monoid (RouteConfig t a) where
-  mempty = def
-  mappend (RouteConfig f1 b1 p1) (RouteConfig f2 b2 p2) =
-    RouteConfig (mappend f1 f2) (mappend b1 b2) (leftmost [p1, p2])
-  mconcat rcs =
-    RouteConfig (mconcat $ map _routeConfig_forward rcs)
-                (mconcat $ map _routeConfig_back rcs)
-                (leftmost $ map _routeConfig_pushState rcs)
-
-data Route t a = Route {
-    _route_value   :: Dynamic t (Either T.Text a)     -- ^ Routing value
-  , _route_fullURI :: Dynamic t (U.URIRef U.Absolute) -- ^ Full URI
-  }
-
-makeLenses ''Route
-
-instance HasValue (Route t a) where
-  type Value (Route t a) = Dynamic t (Either T.Text a)
-  value = _route_value
 
 -------------------------------------------------------------------------------
 -- | Manipulate and track the URL 'GHCJS.DOM.Types.Location' for dynamic
 --   routing of a widget
+--   These sources of URL-bar change will be reflected in the output URI
+--     - Input events to 'route'
+--     - Browser Forward/Back button clicks
+--     - forward/back javascript calls (or 'goForward'/'goBack') Haskell calls
+--     - Any URL changes followed by a popState event
+--   But external calls to pushState that don't manually fire a popState
+--   won't be detected
 route
   :: (HasWebView m, MonadWidget t m)
-  => (Location -> IO (Either T.Text a))
-     -- ^ Decode the part of the path beyond '_routeConfig_pathBase' into an a
-  -> (a -> IO T.Text)
-     -- ^ Encode the routing value to a Text that will be passed to `pushState`
-  -> RouteConfig t a
-    -- ^ Routing widget configuration
-  -> m (Route t a)
-route to from (RouteConfig goForward goBack sSet) = do
-  win     <- askDomWindow
-  loc0    <- liftIO $ windowURI win
-  locVal0 <- liftIO $ to =<< fmap (fromMaybe (error "No location"))
-                                  (getLocation win)
+  => Event t T.Text
+  -> m (Dynamic t (U.URIRef U.Absolute))
+route pushTo = do
+  loc0    <- getURI
+  _ <- performEvent $ ffor pushTo $ \t -> do
+    withHistory $ \h -> pushState h (pToJSVal (0 :: Int)) ("" :: T.Text) t
+    liftIO dispatchEvent'
 
-  Just hist <- liftIO $ getHistory win
-  performEvent_ $ ffor goForward $ \_ -> liftIO (forward hist)
-  performEvent_ $ ffor goBack    $ \_ -> liftIO (back hist)
+  locUpdates <- getPopState
 
-  _ <- performEvent $ ffor sSet $ \t -> liftIO $ do
-    s <- from t
-    pushState hist (pToJSVal (0 :: Int)) ("" :: T.Text) s
-    dispatchEvent'
+  -- Route <$> holdDyn locVal0 (leftmost [sSet, locUpdates]) <*> holdDyn loc0 locs
+  -- Because we trigger a popState manually, there is no more need to use the
+  -- sSet events to update the dynamic uri
+  -- TODO make sure this actually works on all the expected URL bar update sources
+  holdDyn loc0 locUpdates
 
-  locVals <- getPopState to
-  locs <- performEvent $ ffor locVals $ \_ -> liftIO (windowURI win)
-
-  Route <$> holdDyn locVal0 (leftmost [Right <$> sSet, locVals]) <*> holdDyn loc0 locs
-
-
-windowURI :: Window -> IO (U.URIRef U.Absolute)
-windowURI w = do
-  l <- fromMaybe (error "Window has no location") <$> getLocation w
-  either (error "No parse of window location") id . U.parseURI U.laxURIParserOptions . T.encodeUtf8 <$> toString l
-
--------------------------------------------------------------------------------
--- | Route a single page app according to any 'WR.PathInfo' a => a
-webRoute
-  :: (MonadWidget t m, WR.PathInfo a)
-  => T.Text     -- ^ The part of the URL not related to SPA routing
-  -> RouteConfig t a
-  -> m (Route t a)
-webRoute pathBase = route decoder (return . (pathBase <>) . WR.toPathInfo)
-  where
-    decoder l = runExceptT $ do
-      pn <- lift $ getPathname l
-      ExceptT . return $ first T.pack . WR.fromPathInfo . T.encodeUtf8 =<<
-        note (pfxErr pn pathBase) (T.stripPrefix pathBase pn)
+route'
+  :: forall t m a b. MonadWidget t m
+  => (URI -> a -> URI)
+  -> (URI -> b)
+  -> Event t a
+  -> m (Dynamic t b)
+route' encode decode routeUpdate = do
+  rec rUri <- route (T.decodeUtf8 . U.serializeURIRef' <$> urlUpdates)
+      let urlUpdates = attachWith encode (current rUri) routeUpdate
+  return $ decode <$> rUri
 
 
 -------------------------------------------------------------------------------
 -- | Route a single page app according to the part of the path after
 --   pathBase
 partialPathRoute
-  :: MonadWidget t m
-  => T.Text    -- ^ The part of the URL not related to SPA routing
-  -> RouteConfig t T.Text
-  -> m (Route t T.Text)
-partialPathRoute pathBase = route decoder (return . (pathBase <>))
+  :: forall t m. MonadWidget t m
+  => [T.Text]  -- ^ The path segments not related to SPA routing
+  -> Event t [T.Text] -- ^ Updates to the path segments used for routing
+  -> m (Dynamic t [T.Text]) -- ^ Path segments used for routing
+partialPathRoute pathBase pathUpdates = do
+  route' (flip updateUrl) parseParts pathUpdates
   where
-    decoder l = (\pn -> maybe (Left $ pfxErr pn pathBase)
-                              (Right . id) (T.stripPrefix pathBase pn)
-                ) <$> getPathname l
+
+    toPath :: [T.Text] -> BS.ByteString
+    toPath parts =
+      "/" <> BS.intercalate "/" (T.encodeUtf8 <$> (pathBase <> parts))
+
+    updateUrl :: [T.Text] -> URI -> URI
+    updateUrl updateParts u = u & U.pathL .~ toPath updateParts
+
+    parseParts :: URI -> [T.Text]
+    parseParts u =
+      maybe (error . T.unpack $ pfxErr u pathBase) (map T.decodeUtf8) .
+      L.stripPrefix (T.encodeUtf8 <$> pathBase) .
+      BS.split '/' . BS.drop 1 $ u ^. U.pathL
 
 
 -------------------------------------------------------------------------------
--- | Route a single page app according to the full URI
---   The dynamic returned to you will be a Text of the full URI
---   The route string you pass in will be forwarded as-is to
---   pushState.
-fullUriRoute
-  :: MonadWidget t m
-  => RouteConfig t (U.URIRef U.Absolute)
-  -> m (Route t (U.URIRef U.Absolute))
-fullUriRoute cfg = do
-  route uriDecoder (return . T.decodeUtf8 . U.serializeURIRef') cfg
-    where
-      uriDecoder = fmap (first (T.pack . show) .
-                         U.parseURI U.laxURIParserOptions .
-                         T.encodeUtf8) .
-                   toString
-
-
 uriOrigin :: U.URIRef U.Absolute -> T.Text
 uriOrigin r = T.decodeUtf8 $ U.serializeURIRef' r'
   where
@@ -191,6 +135,8 @@ uriOrigin r = T.decodeUtf8 $ U.serializeURIRef' r'
            , U.uriFragment = mempty
            }
 
+
+-------------------------------------------------------------------------------
 #if ghcjs_HOST_OS
 -- | Get the DOM window object.
 askDomWindow :: (HasWebView m, MonadIO m) => m Window
@@ -205,30 +151,57 @@ askDomWindow = error "askDomWindow is only available to ghcjs"
 #endif
 
 
-getPopState :: (MonadWidget t m) => (Location -> IO (Either T.Text a)) -> m (Event t (Either T.Text a))
-getPopState decodeLocation = do
+-------------------------------------------------------------------------------
+getPopState :: (MonadWidget t m) => m (Event t URI)
+getPopState = do
   window <- askDomWindow
-  wrapDomEventMaybe window (`on` popState) $ do
-    liftIO $ getLocation window >>= \case
-      Nothing -> return Nothing
-      Just l  -> Just <$> decodeLocation l
+  wrapDomEventMaybe window (`on` popState) $ liftIO $ do
+    Just loc <- getLocation window
+    locStr <- toString loc
+    return . hush $ U.parseURI U.laxURIParserOptions (T.encodeUtf8 locStr)
+
+
+-------------------------------------------------------------------------------
+goForward :: (HasWebView m, MonadIO m) => m ()
+goForward = withHistory forward
+
+
+-------------------------------------------------------------------------------
+goBack :: (HasWebView m, MonadIO m) => m ()
+goBack = withHistory back
+
+
+-------------------------------------------------------------------------------
+withHistory :: (HasWebView m, MonadIO m) => (History -> IO a) -> m a
+withHistory act = do
+  Just h <- liftIO . getHistory =<< askDomWindow
+  liftIO $ act h
+
 
 
 -------------------------------------------------------------------------------
 -- | (Unsafely) get the 'GHCJS.DOM.Location.Location' of a window
-getLocation' :: (HasWebView m, MonadIO m) => m Location
+getLoc :: (HasWebView m, MonadIO m) => m Location
 #if ghcjs_HOST_OS
-getLocation' = fromMaybe (error "Window has no Location") <$>
-  (askDomWindow >>= liftIO . getLocation)
+getLoc = do
+  Just win <- liftIO . getLocation =<< askDomWindow
+  return win
 #else
-getLocation' = error "getLocation' is only available to ghcjs"
+getLoc = error "getLocation' is only available to ghcjs"
 #endif
 
 
 -------------------------------------------------------------------------------
 -- | (Unsafely) get the URL text of a window
-getUrlText' :: (HasWebView m, MonadIO m) => m T.Text
-getUrlText' = getLocation' >>= liftIO . toString
+getUrlText :: (HasWebView m, MonadIO m) => m T.Text
+getUrlText = getLoc >>= liftIO . toString
+
+
+getURI :: (HasWebView m, MonadIO m) => m URI
+getURI = do
+  l <- getUrlText
+  return $ either (error "No parse of window location") id .
+    U.parseURI U.laxURIParserOptions $ T.encodeUtf8 l
 
 
 #if ghcjs_HOST_OS
@@ -251,9 +224,6 @@ back = undefined
 getLocation :: Window -> IO (Maybe Location)
 getLocation = undefined
 
-getPathname :: Location -> IO T.Text
-getPathname = undefined
-
 getHistory :: Window -> IO (Maybe History)
 getHistory = undefined
 
@@ -275,15 +245,14 @@ data EventName t e
 
 toString :: Location -> IO T.Text
 toString = undefined
+
 #endif
 
--------------------------------------------------------------------------------
--- | Helper functions
-note :: e -> Maybe a -> Either e a
-note _ (Just a) = Right a
-note e _        = Left e
 
+hush :: Either e a -> Maybe a
+hush (Right a) = Just a
+hush _ = Nothing
 
-pfxErr :: T.Text -> T.Text -> T.Text
-pfxErr pn pathBase = "Encountered path (" <> pn
-            <> ") without expected prefix (" <> pathBase <> ")"
+pfxErr :: URI -> [T.Text] -> T.Text
+pfxErr pn pathBase = "Encountered path (" <> T.decodeUtf8 (U.serializeURIRef' pn)
+            <> ") without expected prefix (" <> T.intercalate "/" pathBase <> ")"

--- a/src/Reflex/Dom/Contrib/Router.hs
+++ b/src/Reflex/Dom/Contrib/Router.hs
@@ -76,16 +76,12 @@ route
   -> m (Dynamic t (U.URIRef U.Absolute))
 route pushTo = do
   loc0    <- getURI
+
   _ <- performEvent $ ffor pushTo $ \t -> do
     withHistory $ \h -> pushState h (pToJSVal (0 :: Int)) ("" :: T.Text) t
     liftIO dispatchEvent'
 
   locUpdates <- getPopState
-
-  -- Route <$> holdDyn locVal0 (leftmost [sSet, locUpdates]) <*> holdDyn loc0 locs
-  -- Because we trigger a popState manually, there is no more need to use the
-  -- sSet events to update the dynamic uri
-  -- TODO make sure this actually works on all the expected URL bar update sources
   holdDyn loc0 locUpdates
 
 route'
@@ -241,19 +237,6 @@ getWindowLocation w = do
   getPathname loc
 #endif
 
--- ------------------------------------------------------------------------------
--- getWindowLocation :: Window -> IO T.Text
--- #ifdef ghcjs_HOST_OS
--- getWindowLocation w = do
---     liftM fromJSString $ js_windowLocationPathname (unWindow w)
-
--- foreign import javascript unsafe
---   "$1['location']['pathname']"
---   js_windowLocationPathname :: JSVal -> IO JSVal
--- #else
--- getWindowLocation =
---     error "getWindowLocation: only works in GHCJS"
--- #endif
 
 #if ghcjs_HOST_OS
 foreign import javascript unsafe "w = window; e = new PopStateEvent('popstate',{'view':window,'bubbles':true,'cancelable':true}); w.dispatchEvent(e);"

--- a/src/Reflex/Dom/Contrib/Router.hs
+++ b/src/Reflex/Dom/Contrib/Router.hs
@@ -29,15 +29,10 @@ module Reflex.Dom.Contrib.Router (
 
 ------------------------------------------------------------------------------
 import           Control.Lens              ((&), (.~), (^.))
--- import           Control.Monad             ((<=<))
--- import           Control.Monad.Except      (ExceptT(..), lift, runExceptT)
 import           Control.Monad.IO.Class    (MonadIO, liftIO)
--- import           Data.Bifunctor            (first)
 import qualified Data.ByteString.Char8     as BS
--- import           Data.Maybe                (fromJust, fromMaybe)
 import qualified Data.List                 as L
 import           Data.Monoid               ((<>))
--- import           Data.Default
 import qualified Data.Text                 as T
 import qualified Data.Text.Encoding        as T
 import           GHCJS.DOM.Types           (Location(..) )
@@ -57,7 +52,6 @@ import           Control.Monad.Reader      (ReaderT)
 #endif
 
 
-type URI = U.URIRef U.Absolute
 
 
 -------------------------------------------------------------------------------
@@ -178,7 +172,6 @@ withHistory act = do
   liftIO $ act h
 
 
-
 -------------------------------------------------------------------------------
 -- | (Unsafely) get the 'GHCJS.DOM.Location.Location' of a window
 getLoc :: (HasWebView m, MonadIO m) => m Location
@@ -197,6 +190,11 @@ getUrlText :: (HasWebView m, MonadIO m) => m T.Text
 getUrlText = getLoc >>= liftIO . toString
 
 
+-------------------------------------------------------------------------------
+type URI = U.URIRef U.Absolute
+
+
+-------------------------------------------------------------------------------
 getURI :: (HasWebView m, MonadIO m) => m URI
 getURI = do
   l <- getUrlText

--- a/src/Reflex/Dom/Contrib/Router.hs
+++ b/src/Reflex/Dom/Contrib/Router.hs
@@ -20,8 +20,10 @@ module Reflex.Dom.Contrib.Router (
 
   -- = Low-level URL bar access
   , getLoc
+  , getURI
   , getUrlText
   , uriOrigin
+  , URI
 
   -- = History movement
   , goForward


### PR DESCRIPTION
Generalize `route` function to allow routing over an arbitrary type with user-defined de/serialization functions.

Add three concrete routing strategies
  - `fullUriRoute` consume and produce `uri-bytestring` absolute URIs
  - `partialPathRoute` consume and produce path segments
  - `webRoute` consume and produce any `a` with an `PathInfo` instance from the `web-routes` library