### PR TITLE
Make radio buttons more userfriendly. Fire event also on clicks on th…

### DIFF
--- a/src/Reflex/Dom/Contrib/Widgets/ButtonGroup.hs
+++ b/src/Reflex/Dom/Contrib/Widgets/ButtonGroup.hs
@@ -175,7 +175,7 @@ radioGroup dynName dynEntryList cfg = do
         (b,_) <- elDynAttr' "input" btnAttrs $ return ()
         f <- holdDyn False $ leftmost [ False <$ (Blur  `domEvent` b)
                                       , True  <$ (Focus `domEvent` b)]
-        el "text" $ dynText txt
+        dynText txt
         let e = castToHTMLInputElement $ _element_raw b
         _ <- performEvent $ (liftIO . setChecked e) <$> updated dynChecked
         return (Click `domEvent` b, f)

--- a/src/Reflex/Dom/Contrib/Widgets/ButtonGroup.hs
+++ b/src/Reflex/Dom/Contrib/Widgets/ButtonGroup.hs
@@ -167,15 +167,15 @@ radioGroup dynName dynEntryList cfg = do
      <> bool mempty ("checked" =: "checked") chkd
     handleOne _ dynV dynChecked = do
 
-      el "tr" $ do
+      el "tr" $ el "td" $ el "label" $  do
         let txt = zipDynWith (\v m -> fromMaybe "" $ Prelude.lookup v m)
                              dynV dynEntryList
 
             btnAttrs = mkBtnAttrs <$> dynName <*> dynChecked
-        (b,_) <- el "td" $ elDynAttr' "input" btnAttrs $ return ()
+        (b,_) <- elDynAttr' "input" btnAttrs $ return ()
         f <- holdDyn False $ leftmost [ False <$ (Blur  `domEvent` b)
                                       , True  <$ (Focus `domEvent` b)]
-        el "td" $ dynText txt
+        el "text" $ dynText txt
         let e = castToHTMLInputElement $ _element_raw b
         _ <- performEvent $ (liftIO . setChecked e) <$> updated dynChecked
         return (Click `domEvent` b, f)


### PR DESCRIPTION
A radio button is a small circle and a text to the right of this circle.
With the current implementation the user must click exactly on the little circle. Clicking on the text does not check an unchecked radio button.
This pull request allows the user to click on the text or on the circle.
Implementation notes: The table now contains only one column. The input button is enclosed in a html label element.