### PR TITLE
Function stripPrefix was introduced in bytestring-0.10.8.0

### DIFF
--- a/reflex-dom-contrib.cabal
+++ b/reflex-dom-contrib.cabal
@@ -53,7 +53,7 @@ library
     aeson             >= 0.8  && < 1.1,
     base              >= 4.6  && < 4.10,
     bifunctors        >= 4.0  && < 5.5,
-    bytestring        >= 0.10 && < 0.11,
+    bytestring        >= 0.10.8 && < 0.11,
     base64-bytestring >= 1.0  && < 1.1,
     containers        >= 0.5  && < 0.6,
     data-default      >= 0.5  && < 0.8,


### PR DESCRIPTION
Module *src/Reflex/Dom/Contrib/Router.hs* has an `import qualified Data.ByteString.Char8 as BS` .
In line 119 the function `BS.stripPrefix` is used.
The function `stripPrefix` was first introduced in  *bytestring-0.10.8.0* and is therefore missing in earlier versions (eg 0.10.6.0). To avoid compilation errors, the minimal version of *bytestring* must be set to `0.10.8.0`.

Sorry for destroying the nice tabular display...