### PR TITLE
Use compile time errors instead of runtime errors.

### DIFF
--- a/reflex-dom-contrib.cabal
+++ b/reflex-dom-contrib.cabal
@@ -1,5 +1,5 @@
 name:                reflex-dom-contrib
-version:             0.5
+version:             0.5.1.0
 synopsis:            A place to experiment with infrastructure and common code for reflex applications
 description:         This library is intended to be a public playground for
                      developing infrastructure, higher level APIs, and widget
@@ -44,13 +44,14 @@ library
     Reflex.Dom.Contrib.Widgets.EditInPlace
     Reflex.Dom.Contrib.Widgets.Modal
     Reflex.Dom.Contrib.Widgets.Svg
+    Reflex.Dom.Contrib.Widgets.ScriptDependent
 
   if impl(ghcjs)
    exposed-modules:
      Reflex.Dom.Contrib.Geoposition
 
   build-depends:
-    aeson             >= 0.8  && < 1.1,
+    aeson             >= 0.8  && < 1.2,
     base              >= 4.6  && < 4.10,
     bifunctors        >= 4.0  && < 5.5,
     bytestring        >= 0.10.8 && < 0.11,
@@ -59,13 +60,14 @@ library
     data-default      >= 0.5  && < 0.8,
     ghcjs-dom         >= 0.2  && < 0.3,
     http-types        >= 0.8  && < 0.10,
-    lens              >= 4.9  && < 4.15,
+    lens              >= 4.9  && < 4.16,
     mtl               >= 2.0  && < 2.3,
     random            >= 1.0  && < 1.2,
     readable          >= 0.3  && < 0.4,
     reflex            >= 0.5  && < 0.6,
     reflex-dom        >= 0.4  && < 0.5,
     safe              >= 0.3  && < 0.4,
+    stm               >= 2.1  && < 2.5,
     string-conv       >= 0.1  && < 0.2,
     text              >= 1.2  && < 1.3,
     time              >= 1.5  && < 1.7,

--- a/reflex-dom-contrib.cabal
+++ b/reflex-dom-contrib.cabal
@@ -24,6 +24,11 @@ category:            FRP
 build-type:          Simple
 cabal-version:       >=1.10
 
+Flag include-ghc-stubs
+  Description:   Generate GHC stub functions for GHCJS only functions. 
+                 This allows compilation under GHC when using GHCJS only functions.
+  Default:       True
+
 library
   hs-source-dirs: src
 
@@ -43,12 +48,15 @@ library
     Reflex.Dom.Contrib.Widgets.EditInPlace
     Reflex.Dom.Contrib.Widgets.Modal
     Reflex.Dom.Contrib.Widgets.Svg
-    Reflex.Dom.Contrib.Widgets.ScriptDependent
 
   if impl(ghcjs)
    exposed-modules:
      Reflex.Dom.Contrib.Geoposition
+
+  if impl(ghcjs) || flag(include-ghc-stubs)
+   exposed-modules:
      Reflex.Dom.Contrib.Router
+     Reflex.Dom.Contrib.Widgets.ScriptDependent
 
   build-depends:
     aeson             >= 0.8  && < 1.2,
@@ -82,3 +90,6 @@ library
   default-language:    Haskell2010
 
   ghc-options: -Wall -fwarn-tabs
+
+  if flag(include-ghc-stubs)
+    cpp-options: -DGHCSTUBS

--- a/reflex-dom-contrib.cabal
+++ b/reflex-dom-contrib.cabal
@@ -52,6 +52,7 @@ library
   if impl(ghcjs)
    exposed-modules:
      Reflex.Dom.Contrib.Geoposition
+     Reflex.Dom.Contrib.Router
 
   if impl(ghcjs) || flag(include-ghc-stubs)
    exposed-modules:

--- a/reflex-dom-contrib.cabal
+++ b/reflex-dom-contrib.cabal
@@ -32,7 +32,6 @@ library
     Reflex.Contrib.Utils
     Reflex.Dom.Contrib.KeyEvent
     Reflex.Dom.Contrib.Pagination
-    Reflex.Dom.Contrib.Router
     Reflex.Dom.Contrib.Utils
     Reflex.Dom.Contrib.Xhr
     Reflex.Dom.Contrib.Widgets.BoundedList
@@ -49,6 +48,7 @@ library
   if impl(ghcjs)
    exposed-modules:
      Reflex.Dom.Contrib.Geoposition
+     Reflex.Dom.Contrib.Router
 
   build-depends:
     aeson             >= 0.8  && < 1.2,

--- a/src/Reflex/Dom/Contrib/KeyEvent.hs
+++ b/src/Reflex/Dom/Contrib/KeyEvent.hs
@@ -13,7 +13,7 @@ module Reflex.Dom.Contrib.KeyEvent
   , key
   , shift
   , ctrlKey
-#ifdef ghcjs_HOST_OS
+#if ghcjs_HOST_OS || GHCSTUBS
   , Reflex.Dom.Contrib.KeyEvent.getKeyEvent
 #endif
   ) where
@@ -76,5 +76,8 @@ foreign import javascript unsafe "$1['ctrlKey']"
 
 foreign import javascript unsafe "$1['shiftKey']"
   js_uiEventGetShiftKey :: JSVal -> IO Bool
+#elif GHCSTUBS
+getKeyEvent :: EventM e KeyboardEvent KeyEvent
+getKeyEvent = error "getKeyEvent: can only be used with GHCJS"
 #endif
 

--- a/src/Reflex/Dom/Contrib/KeyEvent.hs
+++ b/src/Reflex/Dom/Contrib/KeyEvent.hs
@@ -13,7 +13,9 @@ module Reflex.Dom.Contrib.KeyEvent
   , key
   , shift
   , ctrlKey
+#ifdef ghcjs_HOST_OS
   , Reflex.Dom.Contrib.KeyEvent.getKeyEvent
+#endif
   ) where
 
 ------------------------------------------------------------------------------
@@ -60,8 +62,8 @@ ctrlKey k = (key $ toUpper k) { keCtrl = True }
 
 
 ------------------------------------------------------------------------------
-getKeyEvent :: EventM e KeyboardEvent KeyEvent
 #ifdef ghcjs_HOST_OS
+getKeyEvent :: EventM e KeyboardEvent KeyEvent
 getKeyEvent = do
   e <- event
   code <- Reflex.Dom.getKeyEvent
@@ -74,7 +76,5 @@ foreign import javascript unsafe "$1['ctrlKey']"
 
 foreign import javascript unsafe "$1['shiftKey']"
   js_uiEventGetShiftKey :: JSVal -> IO Bool
-#else
-getKeyEvent = error "getKeyEvent: can only be used with GHCJS"
 #endif
 

--- a/src/Reflex/Dom/Contrib/Router.hs
+++ b/src/Reflex/Dom/Contrib/Router.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE TemplateHaskell          #-}
 {-# LANGUAGE TypeFamilies             #-}
 
+-- | Note: This module is only available under GHCJS
 module Reflex.Dom.Contrib.Router (
   -- == High-level routers
     route
@@ -39,7 +40,7 @@ import qualified Data.Text.Encoding        as T
 import           GHCJS.DOM.Types           (Location(..))
 import           Reflex.Dom                hiding (EventName, Window)
 import qualified URI.ByteString            as U
-#if ghcjs_HOST_OS
+-- #if ghcjs_HOST_OS
 import qualified GHCJS.DOM                 as DOM
 import           GHCJS.DOM.Document        (getDefaultView)
 import           GHCJS.DOM.EventM          (on)
@@ -48,9 +49,9 @@ import           GHCJS.DOM.Location        (toString)
 import           GHCJS.DOM.Window          (Window, getHistory,
                                             getLocation, popState)
 import           GHCJS.Marshal.Pure
-#else
-import           Control.Monad.Reader      (ReaderT)
-#endif
+-- #else
+-- import           Control.Monad.Reader      (ReaderT)
+-- #endif
 ------------------------------------------------------------------------------
 
 
@@ -134,7 +135,7 @@ uriOrigin r = T.decodeUtf8 $ U.serializeURIRef' r'
 
 
 -------------------------------------------------------------------------------
-#if ghcjs_HOST_OS
+-- #if ghcjs_HOST_OS
 -- | Get the DOM window object.
 askDomWindow :: (HasWebView m, MonadIO m) => m Window
 askDomWindow = do
@@ -142,10 +143,7 @@ askDomWindow = do
   Just doc <- liftIO . DOM.webViewGetDomDocument $ unWebViewSingleton wv
   Just window <- liftIO $ getDefaultView doc
   return window
-#else
-askDomWindow :: (MonadIO m) => m Window
-askDomWindow = error "askDomWindow is only available to ghcjs"
-#endif
+-- #endif
 
 
 -------------------------------------------------------------------------------
@@ -178,13 +176,11 @@ withHistory act = do
 -------------------------------------------------------------------------------
 -- | (Unsafely) get the 'GHCJS.DOM.Location.Location' of a window
 getLoc :: (HasWebView m, MonadIO m) => m Location
-#if ghcjs_HOST_OS
+-- #if ghcjs_HOST_OS
 getLoc = do
   Just win <- liftIO . getLocation =<< askDomWindow
   return win
-#else
-getLoc = error "getLocation' is only available to ghcjs"
-#endif
+-- #endif
 
 
 -------------------------------------------------------------------------------
@@ -205,10 +201,11 @@ getURI = do
     U.parseURI U.laxURIParserOptions $ T.encodeUtf8 l
 
 
-#if ghcjs_HOST_OS
+-- #if ghcjs_HOST_OS
 foreign import javascript unsafe "w = window; e = new PopStateEvent('popstate',{'view':window,'bubbles':true,'cancelable':true}); w['dispatchEvent'](e);"
   dispatchEvent' :: IO ()
-#else
+{-
+-- #else
 data Window
 data JSVal
 data History
@@ -247,8 +244,8 @@ data EventName t e
 toString :: Location -> IO T.Text
 toString = undefined
 
-#endif
-
+-- #endif
+-}
 
 -------------------------------------------------------------------------------
 hush :: Either e a -> Maybe a

--- a/src/Reflex/Dom/Contrib/Utils.hs
+++ b/src/Reflex/Dom/Contrib/Utils.hs
@@ -18,7 +18,7 @@ module Reflex.Dom.Contrib.Utils
   , putDebugLnE
   , listWithKeyAndSelection
   , waitUntilJust
-#ifdef ghcjs_HOST_OS
+#if ghcjs_HOST_OS || GHCSTUBS
   , alertEvent
   , js_alert
   , confirmEvent
@@ -50,13 +50,10 @@ import           Reflex.Dom      hiding (Window, fromJSString)
 tshow :: Show a => a -> Text
 tshow = T.pack . show
 
-
-
-#ifdef ghcjs_HOST_OS
 ------------------------------------------------------------------------------
 -- | Convenient function that pops up a javascript alert dialog box when an
 -- event fires with a message to display.
--- Only for GHCJS
+#ifdef ghcjs_HOST_OS
 alertEvent :: MonadWidget t m => (a -> String) -> Event t a -> m ()
 alertEvent str e = performEvent_ (alert <$> e)
   where
@@ -65,13 +62,16 @@ alertEvent str e = performEvent_ (alert <$> e)
 foreign import javascript unsafe
   "alert($1)"
   js_alert :: JSString -> IO ()
+#elif GHCSTUBS
+alertEvent :: MonadWidget t m => (a -> String) -> Event t a -> m ()
+alertEvent = error "alertEvent: can only be used with GHCJS"
+js_alert = error "js_alert: can only be used with GHCJS"
 #endif
 
-#ifdef ghcjs_HOST_OS
 ------------------------------------------------------------------------------
 -- | Convenient function that pops up a javascript confirmation dialog box
 -- when an event fires with a message to display.
--- Only for GHCJS
+#ifdef ghcjs_HOST_OS
 confirmEvent :: MonadWidget t m => (a -> String) -> Event t a -> m (Event t a)
 confirmEvent str e = liftM (fmapMaybe id) $ performEvent (confirm <$> e)
   where
@@ -82,14 +82,17 @@ confirmEvent str e = liftM (fmapMaybe id) $ performEvent (confirm <$> e)
 foreign import javascript unsafe
   "confirm($1)"
   js_confirm :: JSString -> IO Bool
+#elif GHCSTUBS
+confirmEvent :: MonadWidget t m => (a -> String) -> Event t a -> m (Event t a)
+confirmEvent = error "confirmEvent: can only be used with GHCJS"
+js_confirm = error "js_confirm: can only be used with GHCJS"
 #endif
 
-#ifdef ghcjs_HOST_OS
 ------------------------------------------------------------------------------
 -- | Gets the current path of the DOM Window (i.e., the contents of the
 -- address bar after the host, beginning with a "/").
 -- https://developer.mozilla.org/en-US/docs/Web/API/Location
--- Only for GHCJS
+#ifdef ghcjs_HOST_OS
 getWindowLocationPath :: Window -> IO String
 getWindowLocationPath w = do
     liftM fromJSString $ js_windowLocationPath $ unWindow w
@@ -97,18 +100,23 @@ getWindowLocationPath w = do
 foreign import javascript unsafe
   "$1['location']['pathname']"
   js_windowLocationPath :: JSVal ->  IO JSString
+#elif GHCSTUBS
+getWindowLocationPath :: Window -> IO String
+getWindowLocationPath = error "getWindowLocationPath: can only be used with GHCJS"
 #endif
 
-#ifdef ghcjs_HOST_OS
 ------------------------------------------------------------------------------
 -- | Pushes a new URL to the window history.
--- Only for GHCJS.
+#ifdef ghcjs_HOST_OS
 windowHistoryPushState :: String -> IO ()
 windowHistoryPushState = js_windowHistoryPushState . toJSString
 
 foreign import javascript unsafe
   "window['history']['pushState']({},\"\",$1)"
   js_windowHistoryPushState :: JSString -> IO ()
+#elif GHCSTUBS
+windowHistoryPushState :: String -> IO ()
+windowHistoryPushState = error "windowHistoryPushState: can only be used with GHCJS"
 #endif
 
 #ifdef ghcjs_HOST_OS
@@ -118,6 +126,9 @@ setWindowLoc = js_setWindowLoc . toJSString
 foreign import javascript unsafe
   "window['location'] = window['location']['origin'] + $1;"
   js_setWindowLoc :: JSString -> IO ()
+#elif GHCSTUBS
+setWindowLoc :: String -> IO ()
+setWindowLoc = error "setWindowLoc: can only be used with GHCJS"
 #endif
 
 ------------------------------------------------------------------------------

--- a/src/Reflex/Dom/Contrib/Widgets/ScriptDependent.hs
+++ b/src/Reflex/Dom/Contrib/Widgets/ScriptDependent.hs
@@ -1,0 +1,140 @@
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE JavaScriptFFI       #-}
+{-# LANGUAGE LambdaCase          #-}
+-- | This module provides a method of expressing widgets that depend on an external javascript source.
+module Reflex.Dom.Contrib.Widgets.ScriptDependent
+  ( widgetHoldUntilDefined
+  ) where
+
+import           Control.Concurrent          (forkIO, threadDelay)
+import           Control.Monad               (void)
+import           Control.Monad.IO.Class      (MonadIO, liftIO)
+import           Reflex.Dom
+#ifdef ghcjs_HOST_OS
+import           Control.Concurrent.STM.TVar
+import           Control.Monad.STM (atomically)
+import           Data.Function               (fix)
+import           Data.Time.Clock             (NominalDiffTime, diffUTCTime, getCurrentTime)
+import           GHCJS.Foreign.Callback
+import           Data.JSString (JSString, pack)
+#else
+import           Data.Time.Clock             (NominalDiffTime)
+#endif
+
+
+#ifdef ghcjs_HOST_OS
+
+------------------------------------------------------------------------------
+-- | A 15 second timeout.
+timeout :: NominalDiffTime
+timeout = 15.0
+
+
+------------------------------------------------------------------------------
+-- | Determines if a symbol is defined on the window.
+foreign import javascript unsafe
+ "(function () { \
+   return (typeof window[$1] != 'undefined'); \
+  })()"
+  definedInWindow_js :: JSString -> IO Bool
+
+
+------------------------------------------------------------------------------
+-- | Determines if a symbol is defined on the window.
+definedInWindow :: String -> IO Bool
+definedInWindow = definedInWindow_js . pack
+
+
+------------------------------------------------------------------------------
+-- | Does a script tag injection.
+foreign import javascript unsafe
+  "(function () { \
+     var script = document.createElement('script'); \
+         script.type   = 'text/javascript'; \
+         script.async  = true; \
+         script.onload = function () { \
+           console.log('loaded script ' + $1); \
+           $2(); \
+         }; \
+         script.src = $1; \
+     console.log('loading script ' + $1); \
+     document.getElementsByTagName('head')[0].appendChild(script); \
+   })()"
+  injectScript_js :: JSString -> Callback (IO ()) -> IO ()
+
+
+------------------------------------------------------------------------------
+-- | Inject a script into the current document and wait for it to load or timeout.
+-- The timeout is set to 15 seconds.
+injectScript :: String -> IO () -> IO ()
+injectScript url innerCB = do
+  tvar    <- newTVarIO False
+  outerCB <- asyncCallback $ atomically $ writeTVar tvar True
+  start   <- getCurrentTime
+  injectScript_js (pack url) outerCB
+  void $ forkIO $ fix $ \loop -> readTVarIO tvar >>= \case
+    True  -> releaseCallback outerCB >> innerCB
+    False -> do
+      threadDelay 10
+      now <- getCurrentTime
+      if diffUTCTime now start < timeout
+        then loop
+        else releaseCallback outerCB >> innerCB
+
+
+#else
+
+
+------------------------------------------------------------------------------
+injectScript :: String -> IO () -> IO ()
+injectScript _ innerCB = void $ forkIO $ threadDelay 10 >> innerCB
+
+
+------------------------------------------------------------------------------
+definedInWindow :: String -> IO Bool
+definedInWindow = const $ return False
+
+
+#endif
+
+
+------------------------------------------------------------------------------
+-- | Given a symbol and an event of some url, load the script at that url and
+-- proc an event when loading is complete, or the load times out, whichever
+-- happens first.
+-- If the given symbol already exists, short circuit and proc immediately.
+injectScriptEvent
+  :: (MonadIO (Performable m), PerformEvent t m, TriggerEvent t m)
+  => String
+  -> Event t String
+  -> m (Event t ())
+injectScriptEvent symbol evUrl = performEventAsync $ ffor evUrl $ \url cb ->
+  liftIO $ definedInWindow symbol >>= \case
+    False -> injectScript url $ cb ()
+    True  -> cb ()
+
+
+------------------------------------------------------------------------------
+-- | Render a placeholder widget until a given symbol exists (in the window). If
+-- the symbol has already been loaded, this will switch to the main widget
+-- immediately. If the symbol is not loaded this will load a script using script
+-- tag injection, wait for the load to complete and then switch to the main
+-- widget. This switch happens whether or not the symbol gets defined by the
+-- script, so make sure you have the correct symbol!
+widgetHoldUntilDefined
+  :: (MonadWidget t m, PerformEvent t m, TriggerEvent t m)
+  => String
+  -- ^ Symbol, for instance the value "dhtmlxCalendarObject", as in
+  -- window.dhtmlxCalendarObject
+  -> Event t String
+  -- ^ An event of the url to load
+  -> m a
+  -- ^ The placeholder widget
+  -> m a
+  -- ^ The main widget
+  -> m (Dynamic t a)
+widgetHoldUntilDefined symbol evUrl placeholder widget = do
+  evLoaded <- injectScriptEvent symbol =<< debounce 0.75 evUrl
+  widgetHold placeholder (widget <$ evLoaded)


### PR DESCRIPTION
This PR hides GHCJS only functions from GHC users. Therefore runtime errors like **alertEvent: can only be used with GHCJS*" are no longer possible.

In the module *Router.hs* I could not find a function that works under GHC. Therfore this module is now completly hidden from GHC users. I intentionally  uncommented *#ifdef ghcjs_HOST_OS* conditions. You may eventually use them again, when you implement the GHC version for the function *dispatchEvent'*.