### PR TITLE
Create a flag to issue compile time errors instead of runtime errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.5.1
+
+* Compilation flag *include-ghc-stubs*. If set to false, ghcjs only functions give 
+  compile time error messages, when compiled with GHC.
+
 # 0.5
 
 * Add route, fullUriRoute, partialPathRoute

--- a/reflex-dom-contrib.cabal
+++ b/reflex-dom-contrib.cabal
@@ -24,6 +24,11 @@ category:            FRP
 build-type:          Simple
 cabal-version:       >=1.10
 
+Flag include-ghc-stubs
+  Description:   Generate GHC stub functions for GHCJS only functions. 
+                 This allows compilation under GHC when using GHCJS only functions.
+  Default:       True
+
 library
   hs-source-dirs: src
 
@@ -32,7 +37,6 @@ library
     Reflex.Contrib.Utils
     Reflex.Dom.Contrib.KeyEvent
     Reflex.Dom.Contrib.Pagination
-    Reflex.Dom.Contrib.Router
     Reflex.Dom.Contrib.Utils
     Reflex.Dom.Contrib.Xhr
     Reflex.Dom.Contrib.Widgets.BoundedList
@@ -44,11 +48,15 @@ library
     Reflex.Dom.Contrib.Widgets.EditInPlace
     Reflex.Dom.Contrib.Widgets.Modal
     Reflex.Dom.Contrib.Widgets.Svg
-    Reflex.Dom.Contrib.Widgets.ScriptDependent
 
   if impl(ghcjs)
    exposed-modules:
      Reflex.Dom.Contrib.Geoposition
+
+  if impl(ghcjs) || flag(include-ghc-stubs)
+   exposed-modules:
+     Reflex.Dom.Contrib.Router
+     Reflex.Dom.Contrib.Widgets.ScriptDependent
 
   build-depends:
     aeson             >= 0.8  && < 1.2,
@@ -82,3 +90,6 @@ library
   default-language:    Haskell2010
 
   ghc-options: -Wall -fwarn-tabs
+
+  if flag(include-ghc-stubs)
+    cpp-options: -DGHCSTUBS

--- a/src/Reflex/Dom/Contrib/KeyEvent.hs
+++ b/src/Reflex/Dom/Contrib/KeyEvent.hs
@@ -13,7 +13,9 @@ module Reflex.Dom.Contrib.KeyEvent
   , key
   , shift
   , ctrlKey
+#if ghcjs_HOST_OS || GHCSTUBS
   , Reflex.Dom.Contrib.KeyEvent.getKeyEvent
+#endif
   ) where
 
 ------------------------------------------------------------------------------
@@ -60,8 +62,8 @@ ctrlKey k = (key $ toUpper k) { keCtrl = True }
 
 
 ------------------------------------------------------------------------------
-getKeyEvent :: EventM e KeyboardEvent KeyEvent
 #ifdef ghcjs_HOST_OS
+getKeyEvent :: EventM e KeyboardEvent KeyEvent
 getKeyEvent = do
   e <- event
   code <- Reflex.Dom.getKeyEvent
@@ -74,7 +76,8 @@ foreign import javascript unsafe "$1['ctrlKey']"
 
 foreign import javascript unsafe "$1['shiftKey']"
   js_uiEventGetShiftKey :: JSVal -> IO Bool
-#else
+#elif GHCSTUBS
+getKeyEvent :: EventM e KeyboardEvent KeyEvent
 getKeyEvent = error "getKeyEvent: can only be used with GHCJS"
 #endif
 


### PR DESCRIPTION
This is the second incarnation of [my PR](https://github.com/reflex-frp/reflex-dom-contrib/pull/31) to issue error messages when a GHC user tries to use a GHCJS only function. To activate this functionality the cabal compile time flag *include-ghc-stubs* must be set to false. 