### PR TITLE
update Router to satisfy jsaddle

### DIFF
--- a/src/Reflex/Dom/Contrib/Router.hs
+++ b/src/Reflex/Dom/Contrib/Router.hs
@@ -78,9 +78,9 @@ route pushTo = do
   _ <- performEvent $ ffor pushTo $ \t -> do
     let newState =
 #if MIN_VERSION_ghcjs_dom(0,8,0)
-          Just t
-#else
           t
+#else
+          Just t
 #endif
     withHistory $ \h -> pushState h (pToJSVal (0 :: Int)) ("" :: T.Text) newState
     liftIO dispatchEvent'
@@ -149,9 +149,9 @@ getPopState = do
   window <- currentWindowUnchecked
   wrapDomEventMaybe window (`on` popState) $ liftIO $ do
 #if MIN_VERSION_ghcjs_dom(0,8,0)
-    loc
-#else
     Just loc
+#else
+    loc
 #endif
       <- getLocation window
     locStr <- getHref loc
@@ -172,9 +172,9 @@ goBack = withHistory back
 withHistory :: (HasJSContext m, MonadIO m) => (History -> IO a) -> m a
 withHistory act = do
 #if MIN_VERSION_ghcjs_dom(0,8,0)
-  h
-#else
   Just h
+#else
+  h
 #endif
     <- liftIO . getHistory =<< currentWindowUnchecked
   liftIO $ act h

--- a/src/Reflex/Dom/Contrib/Widgets/ButtonGroup.hs
+++ b/src/Reflex/Dom/Contrib/Widgets/ButtonGroup.hs
@@ -22,7 +22,7 @@ import           Data.Maybe                 (fromMaybe, listToMaybe)
 import           Data.Monoid                ((<>))
 import           Data.Text                  (Text)
 import           GHCJS.DOM.HTMLInputElement (getChecked,setChecked,HTMLInputElement(..))
-import GHCJS.DOM.Types (MonadJSM, File, uncheckedCastTo)
+import GHCJS.DOM.Types (MonadJSM, File, uncheckedCastTo, Element(..))
 import           Reflex.Dom
 ------------------------------------------------------------------------------
 import           Reflex.Dom.Contrib.Widgets.Common


### PR DESCRIPTION
I have a project which use jsaddle-wkwebview and it compiled with GHC.  I am using cabal-install head to cmpile my project, so I add both jsaddle, jsaddle-wkwebview and reflex-dom-contrib (along with reflex and reflex-dom) to build locally.

After I get  this error:
```
src/Reflex/Dom/Contrib/Router.hs:85:74: error:
    • Couldn't match expected type ‘T.Text’
                  with actual type ‘Maybe T.Text’
    • In the fourth argument of ‘pushState’, namely ‘newState’
      In the expression:
        pushState h (pToJSVal (0 :: Int)) ("" :: T.Text) newState
      In the second argument of ‘($)’, namely
        ‘\ h -> pushState h (pToJSVal (0 :: Int)) ("" :: T.Text) newState’

src/Reflex/Dom/Contrib/Router.hs:157:23: error:
    • Couldn't match expected type ‘Location’
                  with actual type ‘Maybe Location’
    • In the first argument of ‘getHref’, namely ‘loc’
      In a stmt of a 'do' block: locStr <- getHref loc
      In the second argument of ‘($)’, namely
        ‘do { loc <- getLocation window;
              locStr <- getHref loc;
              return . hush
              $ U.parseURI U.laxURIParserOptions (T.encodeUtf8 locStr) }’

src/Reflex/Dom/Contrib/Router.hs:180:16: error:
    • Couldn't match expected type ‘History’
                  with actual type ‘Maybe History’
    • In the first argument of ‘act’, namely ‘h’
      In the second argument of ‘($)’, namely ‘act h’
      In a stmt of a 'do' block: liftIO $ act h
CallStack (from HasCallStack):
```

I try to change the Router.hs to satisfy the compiler (as in this commit) including the ButtonGroup.hs

I am not sure on whether this is right or not, please comment. This fixed the build.