### PR TITLE
Use reflex-dom-core to support jsaddle better

### DIFF
--- a/reflex-dom-contrib.cabal
+++ b/reflex-dom-contrib.cabal
@@ -25,7 +25,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 Flag include-ghc-stubs
-  Description:   Generate GHC stub functions for GHCJS only functions. 
+  Description:   Generate GHC stub functions for GHCJS only functions.
                  This allows compilation under GHC when using GHCJS only functions.
   Default:       True
 
@@ -73,7 +73,7 @@ library
     random            >= 1.0  && < 1.2,
     readable          >= 0.3  && < 0.4,
     reflex            >= 0.5  && < 0.6,
-    reflex-dom        >= 0.4  && < 0.5,
+    reflex-dom-core   >= 0.4  && < 0.5,
     safe              >= 0.3  && < 0.4,
     stm               >= 2.1  && < 2.5,
     string-conv       >= 0.1  && < 0.2,

--- a/src/Reflex/Dom/Contrib/KeyEvent.hs
+++ b/src/Reflex/Dom/Contrib/KeyEvent.hs
@@ -26,7 +26,7 @@ import           GHCJS.DOM.Types hiding (Event)
 #ifdef ghcjs_HOST_OS
 import           GHCJS.Types
 #endif
-import           Reflex.Dom
+import           Reflex.Dom.Core
 ------------------------------------------------------------------------------
 
 

--- a/src/Reflex/Dom/Contrib/Pagination.hs
+++ b/src/Reflex/Dom/Contrib/Pagination.hs
@@ -28,7 +28,7 @@ import qualified Data.Text as T
 import           Data.Time
 import           Data.Word
 import           Reflex
-import           Reflex.Dom
+import           Reflex.Dom.Core
 ------------------------------------------------------------------------------
 import           Reflex.Dom.Contrib.Xhr
 ------------------------------------------------------------------------------
@@ -187,7 +187,7 @@ prune
     => Int
     -> PaginationCache k (PaginationResults v)
     -> PaginationCache k (PaginationResults v)
-prune n m = 
+prune n m =
     M.fromList $ map g $ groupBy ((==) `on` fst) $ sortBy (comparing fst) $
     drop n $ sortBy (comparing $ _prTimestamp . _pvValue . snd) $
     concatMap f $ M.toList m

--- a/src/Reflex/Dom/Contrib/Router.hs
+++ b/src/Reflex/Dom/Contrib/Router.hs
@@ -37,7 +37,7 @@ import           Data.Monoid                   ((<>))
 import qualified Data.Text                     as T
 import qualified Data.Text.Encoding            as T
 import           GHCJS.DOM.Types               (Location(..))
-import           Reflex.Dom                    hiding (EventName, Window)
+import           Reflex.Dom.Core               hiding (EventName, Window)
 import qualified URI.ByteString                as U
 import           GHCJS.DOM.Types               (MonadJSM)
 import           GHCJS.DOM.History             (History, back, forward, pushState)

--- a/src/Reflex/Dom/Contrib/Utils.hs
+++ b/src/Reflex/Dom/Contrib/Utils.hs
@@ -43,7 +43,7 @@ import           GHCJS.DOM.Types hiding (Text, Event)
 import           GHCJS.Types
 #endif
 import           Reflex
-import           Reflex.Dom      hiding (Window, fromJSString)
+import           Reflex.Dom.Core hiding (Window, fromJSString)
 ------------------------------------------------------------------------------
 
 

--- a/src/Reflex/Dom/Contrib/Widgets/BoundedList.hs
+++ b/src/Reflex/Dom/Contrib/Widgets/BoundedList.hs
@@ -40,7 +40,7 @@ import qualified Data.Map as M
 import           Data.Monoid
 import           Data.Text (Text)
 import           Reflex
-import           Reflex.Dom
+import           Reflex.Dom.Core
 ------------------------------------------------------------------------------
 import           Reflex.Contrib.Interfaces
 import           Reflex.Contrib.Utils

--- a/src/Reflex/Dom/Contrib/Widgets/ButtonGroup.hs
+++ b/src/Reflex/Dom/Contrib/Widgets/ButtonGroup.hs
@@ -24,7 +24,7 @@ import           Data.Text                  (Text)
 import           GHCJS.DOM.Element          (Element (..))
 import           GHCJS.DOM.HTMLInputElement (setChecked, HTMLInputElement (..))
 import           GHCJS.DOM.Types            (MonadJSM, castTo)
-import           Reflex.Dom
+import           Reflex.Dom.Core
 ------------------------------------------------------------------------------
 import           Reflex.Dom.Contrib.Widgets.Common
 ------------------------------------------------------------------------------

--- a/src/Reflex/Dom/Contrib/Widgets/CheckboxList.hs
+++ b/src/Reflex/Dom/Contrib/Widgets/CheckboxList.hs
@@ -11,7 +11,7 @@ import           Data.Set (Set)
 import qualified Data.Set as S
 import           Data.Text (Text)
 import           Reflex
-import           Reflex.Dom
+import           Reflex.Dom.Core
 import           Reflex.Dom.Contrib.Widgets.Common
 ------------------------------------------------------------------------------
 

--- a/src/Reflex/Dom/Contrib/Widgets/Common.hs
+++ b/src/Reflex/Dom/Contrib/Widgets/Common.hs
@@ -40,7 +40,7 @@ import           Data.Text (Text)
 import           Data.Time
 import           GHCJS.DOM.HTMLInputElement hiding (setValue)
 import           Reflex
-import           Reflex.Dom
+import           Reflex.Dom.Core
 import           Safe
 ------------------------------------------------------------------------------
 import           Reflex.Contrib.Utils

--- a/src/Reflex/Dom/Contrib/Widgets/DynTabs.hs
+++ b/src/Reflex/Dom/Contrib/Widgets/DynTabs.hs
@@ -38,7 +38,7 @@ import qualified Data.Set                 as S
 import           Data.Text                (Text)
 import qualified Data.Text                as T
 import           Reflex
-import           Reflex.Dom
+import           Reflex.Dom.Core
 ------------------------------------------------------------------------------
 import           Reflex.Dom.Contrib.Utils
 ------------------------------------------------------------------------------

--- a/src/Reflex/Dom/Contrib/Widgets/DynamicList.hs
+++ b/src/Reflex/Dom/Contrib/Widgets/DynamicList.hs
@@ -7,7 +7,7 @@ module Reflex.Dom.Contrib.Widgets.DynamicList where
 import qualified Data.Map as M
 import           Data.Monoid
 import           Reflex
-import           Reflex.Dom
+import           Reflex.Dom.Core
 ------------------------------------------------------------------------------
 
 ------------------------------------------------------------------------------

--- a/src/Reflex/Dom/Contrib/Widgets/EditInPlace.hs
+++ b/src/Reflex/Dom/Contrib/Widgets/EditInPlace.hs
@@ -24,7 +24,7 @@ import qualified Data.Text as T
 import           GHCJS.DOM.Element
 import           GHCJS.DOM.HTMLElement
 import           Reflex
-import           Reflex.Dom
+import           Reflex.Dom.Core
 import           Reflex.Dom.Contrib.Utils
 import           Reflex.Dom.Contrib.Widgets.Common
 import           GHCJS.DOM.Types (MonadJSM)

--- a/src/Reflex/Dom/Contrib/Widgets/Modal.hs
+++ b/src/Reflex/Dom/Contrib/Widgets/Modal.hs
@@ -22,7 +22,7 @@ import           Data.Text (Text)
 import           Data.Monoid
 import           Reflex
 import           Reflex.Contrib.Utils
-import           Reflex.Dom
+import           Reflex.Dom.Core
 import           Reflex.Dom.Contrib.Utils
 ------------------------------------------------------------------------------
 

--- a/src/Reflex/Dom/Contrib/Widgets/ScriptDependent.hs
+++ b/src/Reflex/Dom/Contrib/Widgets/ScriptDependent.hs
@@ -11,7 +11,7 @@ module Reflex.Dom.Contrib.Widgets.ScriptDependent
 import           Control.Concurrent          (forkIO, threadDelay)
 import           Control.Monad               (void)
 import           Control.Monad.IO.Class      (MonadIO, liftIO)
-import           Reflex.Dom
+import           Reflex.Dom.Core
 #ifdef ghcjs_HOST_OS
 import           Control.Concurrent.STM.TVar
 import           Control.Monad.STM (atomically)

--- a/src/Reflex/Dom/Contrib/Widgets/Svg.hs
+++ b/src/Reflex/Dom/Contrib/Widgets/Svg.hs
@@ -27,7 +27,7 @@ import qualified Data.Map   as Map
 import           Data.Text  (Text)
 import           Data.Text  (Text)
 import           Reflex
-import           Reflex.Dom
+import           Reflex.Dom.Core
 ------------------------------------------------------------------------------
 
 {-# INLINABLE svgDynAttr' #-}

--- a/src/Reflex/Dom/Contrib/Xhr.hs
+++ b/src/Reflex/Dom/Contrib/Xhr.hs
@@ -30,7 +30,7 @@ import qualified Data.Text as T
 import           Network.HTTP.Types.URI
 ------------------------------------------------------------------------------
 import           Reflex
-import           Reflex.Dom
+import           Reflex.Dom.Core
 ------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
By using reflex-dom-core directly it makes it easier to choose
to use a different jsaddle runner from the default one that is
selected by reflex-dom.