### PR TITLE
getLoc also works in ghc with newer ghcjs-dom.

### DIFF
--- a/reflex-dom-contrib.cabal
+++ b/reflex-dom-contrib.cabal
@@ -66,7 +66,7 @@ library
     bytestring        >= 0.10.8 && < 0.11,
     containers        >= 0.5  && < 0.6,
     data-default      >= 0.5  && < 0.8,
-    ghcjs-dom         >= 0.2  && < 0.9,
+    ghcjs-dom         >= 0.7  && < 0.9,
     http-types        >= 0.8  && < 0.10,
     lens              >= 4.9  && < 4.16,
     mtl               >= 2.0  && < 2.3,

--- a/src/Reflex/Dom/Contrib/Router.hs
+++ b/src/Reflex/Dom/Contrib/Router.hs
@@ -179,7 +179,6 @@ withHistory act = do
 -------------------------------------------------------------------------------
 -- | (Unsafely) get the 'GHCJS.DOM.Location.Location' of a window
 getLoc :: (HasJSContext m, MonadJSM m) => m Location
-#if ghcjs_HOST_OS
 getLoc = do
   Just win <- currentWindow
 #if MIN_VERSION_ghcjs_dom(0,8,0)
@@ -189,9 +188,6 @@ getLoc = do
 #endif
     <- getLocation win
   return loc
-#else
-getLoc = error "getLocation' is only available to ghcjs"
-#endif
 
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
* Not sure with which version of ghcjs-dom this used to break,
  but tested with 0.8 and works fine.