### PR TITLE
Switched tagPromptlyDyn to tag in mkModalBody

### DIFF
--- a/src/Reflex/Dom/Contrib/Widgets/Modal.hs
+++ b/src/Reflex/Dom/Contrib/Widgets/Modal.hs
@@ -119,7 +119,7 @@ mkModalBody header footer body = do
       dismiss <- header
       bodyRes <- divClass "modal-body" body
       (cancel, ok) <- footer bodyRes
-      let resE1 = tagPromptlyDyn bodyRes ok
+      let resE1 = tag (current bodyRes) ok
       let closem1 = leftmost
             [dismiss, cancel, () <$ ffilter isRight resE1]
       return (resE1, closem1)


### PR DESCRIPTION
Changed the tagPromptlyDyn in mkModalBody to tag.  I can't see why promptness is helpful there (since there is no reason for the ok event to be in the same frame as any changes to the body widget) but that tagPromptlyDyn can create a causality loop if the result from the modal is used somehow in creating the body widget itself. 