### PR TITLE
Support empty static prefix in MonadRouted

### DIFF
--- a/src/Reflex/Dom/Contrib/MonadRouted.hs
+++ b/src/Reflex/Dom/Contrib/MonadRouted.hs
@@ -346,7 +346,7 @@ partsToPath :: [PathSegment] -> T.Text
 partsToPath = T.intercalate "/"
 
 uriPathParts :: URIRef Absolute -> [PathSegment]
-uriPathParts = T.splitOn "/" . cleanT . decodeUtf8 . uriPath
+uriPathParts = pathParts . decodeUtf8 . uriPath
 
 uriToPath :: URIRef Absolute -> T.Text
 uriToPath = partsToPath . uriPathParts


### PR DESCRIPTION
I have added support for an empty static prefix (or equivalently 'context root'), such that you can now write a single page app at the root path, e.g. `http://example.com` instead of `http://example.com/mySinglePageApp`.
Previously, using an empty context root resulted in URLs with double slashes at the beginning and an inability to parse the URL.

I have tested the change manually by running my app with
 * `routeApp ""`
 * `routeApp "/"`
 * `routeApp "foo"`
 * `routeApp "foo/bar"`
and checking the output of my top-level `withPathSegment` when visiting 
 * the context root of the application
 * the context root of the application + `"/"`
 * the context root of the application + `"/somePath"`

The behavior is consistent with the unmodified version for non-empty context roots. Additionally, empty context roots now work.
