### PR TITLE
Raised upper bounds on 'base' and 'time'  in cabal file

### DIFF
--- a/reflex-dom-contrib.cabal
+++ b/reflex-dom-contrib.cabal
@@ -84,7 +84,7 @@ library
     stm                    >= 2.1    && < 2.5,
     string-conv            >= 0.1    && < 0.2,
     text                   >= 1.2    && < 1.3,
-    time                   >= 1.5    && < 2,0,
+    time                   >= 1.5    && < 2.0,
     transformers           >= 0.4    && < 0.6,
     uri-bytestring         >= 0.2    && < 0.3
 

--- a/reflex-dom-contrib.cabal
+++ b/reflex-dom-contrib.cabal
@@ -63,7 +63,7 @@ library
 
   build-depends:
     aeson                  >= 0.8    && < 1.3,
-    base                   >= 4.6    && < 4.10,
+    base                   >= 4.6    && < 4.11,
     base64-bytestring      >= 1.0    && < 1.1,
     bifunctors             >= 4.0    && < 5.5,
     bytestring             >= 0.10.8 && < 0.11,
@@ -84,7 +84,7 @@ library
     stm                    >= 2.1    && < 2.5,
     string-conv            >= 0.1    && < 0.2,
     text                   >= 1.2    && < 1.3,
-    time                   >= 1.5    && < 1.7,
+    time                   >= 1.5    && < 2,0,
     transformers           >= 0.4    && < 0.6,
     uri-bytestring         >= 0.2    && < 0.3
 


### PR DESCRIPTION
In order for reflex-dom-contrib to compile with ghc-8.2.1, at least via reflex-platform, the upper bound on base needs to be raised to include base-4.10.x.x and on time to include time-1.9.x.x.

(Apologies for the typo in the commit message!)
