### PR TITLE
add more efficient dropdown

### DIFF
--- a/reflex-dom-contrib.cabal
+++ b/reflex-dom-contrib.cabal
@@ -63,6 +63,7 @@ library
     base                   >= 4.6    && < 4.13,
     base64-bytestring      >= 1.0    && < 1.1,
     bifunctors             >= 4.0    && < 5.6,
+    bimap                  >= 0.3    && < 0.4,
     bytestring             >= 0.10.8 && < 0.11,
     containers             >= 0.5    && < 0.7,
     data-default           >= 0.5    && < 0.8,

--- a/src/Reflex/Dom/Contrib/Widgets/Common.hs
+++ b/src/Reflex/Dom/Contrib/Widgets/Common.hs
@@ -28,10 +28,13 @@ module Reflex.Dom.Contrib.Widgets.Common where
 import           Control.Applicative
 import           Control.Lens
 import           Control.Monad
+import           Control.Monad.Fix
 import           Data.Default
 import           Data.List
 import           Data.Map (Map)
+import           Data.Bimap (Bimap)
 import qualified Data.Map as M
+import qualified Data.Bimap as BM
 import           Data.Maybe
 import           Data.Monoid
 import           Data.Readable
@@ -500,4 +503,27 @@ listDropdown xs f attrs defS = do
       opts = (M.insert 0 defS) . M.map f <$> m
   sel <- liftM _dropdown_value $ dropdown 0 opts $ def & attributes .~ attrs
   return $ zipDynWith M.lookup sel m
+
+------------------------------------------------------------------------------
+-- | More efficient dropdown.
+dropdownContrib :: forall k t m. (DomBuilder t m, MonadFix m, MonadHold t m, PostBuild t m, Ord k) => 
+  k -> Dynamic t (Bimap k Text) -> DropdownConfig t k -> m (Dropdown t k)
+dropdownContrib k0 options (DropdownConfig setK attrs) = do
+  defaultKey <- holdDyn k0 setK
+  modifyAttrs <- dynamicAttributesToModifyAttributes attrs
+  let indexedOptions :: Dynamic t (Map k Text)
+      indexedOptions = BM.toMap <$> options
+  let cfg = def
+        & selectElementConfig_elementConfig . elementConfig_modifyAttributes .~ fmap mapKeysToAttributeName modifyAttrs
+        & selectElementConfig_setValue .~ attachPromptlyDynWithMaybe (flip BM.lookup) options setK
+  (eRaw, _) <- selectElement cfg $ listWithKey indexedOptions $ \k v -> do
+    let optionAttrs = (\dk v' -> "value" =: v' <> if dk == k then "selected" =: "selected" else mempty) <$> defaultKey <*> v
+    elDynAttr "option" optionAttrs $ dynText v
+  let eChange :: Event t k
+      eChange = attachPromptlyDynWithMaybe safeLookupR options $ _selectElement_change eRaw
+  dValue <- holdDyn k0 $ leftmost [eChange, setK]
+  pure $ Dropdown dValue eChange
+  where
+  safeLookupR :: (Ord x, Ord y) => Bimap x y -> y -> Maybe x
+  safeLookupR bi a = BM.lookupR a bi
 


### PR DESCRIPTION
the full motivation is here https://github.com/reflex-frp/reflex-dom/issues/252
to summarize: the `dropdown` in reflex-dom has the type signature
```haskell
dropdown :: forall k t m. (DomBuilder t m, MonadFix m, MonadHold t m, PostBuild t m, Ord k) => k -> Dynamic t (Map k Text) -> DropdownConfig t k -> m (Dropdown t k)
```
where `Dynamic t (Map k Text)` is the map of haskell values to their textual representations
this is misleading and inefficient because internally, the function converts this Map to a Bimap.
the dropdown function requires allocating:

- `Map` to be passed as an argument
- new `Map` with `Int` indexes
- `Bimap` with `Int` indexes (`Bimap`s are represented by two `Map`s

along with calling toList and fromList all over the place, requiring two lookups, calling readMaybe, etc.

also, I personally experienced confusion before looking at the implementation as to why non-unique values would be deleted from my dropdown menu.

this pr adds a dropdown with the type signature
```haskell
dropdownContrib :: forall k t m. (DomBuilder t m, MonadFix m, MonadHold t m, PostBuild t m, Ord k)
   k -> Dynamic t (Bimap k Text) -> DropdownConfig t k -> m (Dropdown t k) 
```
which is more transparent and repeats much less work.