### PR TITLE
remove HasJSContext

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,11 @@
-{ rpRef ? "4b4a2c8679d6f3042180d2974b31c43bfc506b91"
-, rpSha ? "185i8ccqk0xc05ckd921fs7nnaj88gihmlazny1dk004hxq78cj2"
+{ rpRef ? "ae415044d5ef35d947f0689a66f349ae9e2b7aee"
+, rpSha ? "0mpipci4mxpaqfn2iqc6gwh0n11rvp1l2fz7g703gp12djr8srfd"
 }:
 
-let rp = builtins.fetchTarball {
-  url = "https://github.com/reflex-frp/reflex-platform/archive/${rpRef}.tar.gz";
-  sha256 = rpSha;
+let
+  rp = builtins.fetchTarball {
+    url = "https://github.com/reflex-frp/reflex-platform/archive/${rpRef}.tar.gz";
+    sha256 = rpSha;
 };
 
 in
@@ -15,14 +16,16 @@ in
         rev = "4f2d85f2f1aa4c6bff2d9fcfd3caad443f35476e";
         sha256 = "1vzfi3i3fpl8wqs1yq95jzdi6cpaby80n8xwnwa8h2jvcw3j7kdz";
       }) {};
+      doJailbreak = pkgs.haskell.lib.doJailbreak;
   in
   {
     name = "reflex-dom-contrib";
     overrides = self: super: with pkgs.haskell.lib;
-       {
-       };
+      {
+        reflex-dom-contrib = doJailbreak (super.reflex-dom-contrib); 
+      };
     packages = {
-      reflex-dom-contrib = gitignore.gitignoreSource [] ./.;
+      reflex-dom-contrib = (gitignore.gitignoreSource [] ./.);
     };
     shellToolOverrides = ghc: super: {
       ghcid = pkgs.haskellPackages.ghcid;

--- a/reflex-dom-contrib.cabal
+++ b/reflex-dom-contrib.cabal
@@ -58,37 +58,37 @@ library
      Reflex.Dom.Contrib.Router
      Reflex.Dom.Contrib.Widgets.ScriptDependent
 
-  build-depends:
-    aeson                  >= 0.8    && < 1.5,
-    base                   >= 4.6    && < 4.14,
-    base64-bytestring      >= 1.0    && < 1.1,
-    bifunctors             >= 4.0    && < 5.6,
-    bimap                  >= 0.3    && < 0.4,
-    bytestring             >= 0.10.8 && < 0.11,
-    containers             >= 0.5    && < 0.7,
-    data-default           >= 0.5    && < 0.8,
-    exception-transformers >= 0.4    && < 0.5,
-    exceptions             >= 0.8    && < 0.11,
-    ghcjs-dom              >= 0.7    && < 0.10,
-    http-types             >= 0.8    && < 0.13,
-    jsaddle                >= 0.8    && < 0.10,
-    lens                   >= 4.9    && < 4.19,
-    mtl                    >= 2.0    && < 2.3,
-    random                 >= 1.0    && < 1.2,
-    readable               >= 0.3    && < 0.4,
-    ref-tf                 >= 0.4    && < 0.5,
-    reflex                 >= 0.5    && < 0.9,
-    reflex-dom-core        >= 0.4    && < 0.7,
-    safe                   >= 0.3    && < 0.4,
-    stm                    >= 2.1    && < 2.6,
-    string-conv            >= 0.1    && < 0.2,
-    text                   >= 1.2    && < 1.3,
-    time                   >= 1.5    && < 2.0,
-    transformers           >= 0.4    && < 0.6,
-    uri-bytestring         >= 0.2    && < 0.4
-
+  build-depends: base 
+               , aeson                  
+               , base                   
+               , base64-bytestring      
+               , bifunctors             
+               , bimap                  
+               , bytestring             
+               , containers             
+               , data-default           
+               , exception-transformers 
+               , exceptions             
+               , ghcjs-dom              
+               , http-types             
+               , jsaddle                
+               , lens                   
+               , mtl                    
+               , random                 
+               , readable               
+               , ref-tf                 
+               , reflex                 
+               , reflex-dom-core        
+               , safe                   
+               , stm                    
+               , string-conv            
+               , text                   
+               , time                   
+               , transformers           
+               , uri-bytestring         
+               
   if !impl(ghc >= 8.0)
-    build-depends: semigroups >= 0.16 && < 0.19
+    build-depends: semigroups 
 
   if impl(ghcjs)
     build-depends:

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/22m8j7fcj1iz1jlk30p7hn8qliqg2jcj-reflex-dom-contrib-0.6

--- a/src/Reflex/Dom/Contrib/MonadRouted.hs
+++ b/src/Reflex/Dom/Contrib/MonadRouted.hs
@@ -168,10 +168,6 @@ instance MonadDynamicWriter t w m => MonadDynamicWriter t w (RouteT t m) where
 instance EventWriter t w m => EventWriter t w (RouteT t m) where
   tellEvent = lift . tellEvent
 
-instance HasJSContext m => HasJSContext (RouteT t m) where
-  type JSContextPhantom (RouteT t m) = JSContextPhantom m
-  askJSContext = lift askJSContext
-
 instance (MonadHold t m, MonadFix m, Adjustable t m) => Adjustable t (RouteT t m) where
   runWithReplace a0 a' = RouteT $ runWithReplace (coerce a0) (coerceEvent a')
   traverseIntMapWithKeyWithAdjust f dm0 dm' = RouteT $ traverseIntMapWithKeyWithAdjust
@@ -228,7 +224,7 @@ askUri = do
 
 -- | Path segments of original url
 askInitialSegments
-    :: (Monad m, MonadJSM m, HasJSContext m, MonadRouted t m)
+    :: (Monad m, MonadJSM m, MonadRouted t m)
     => m [PathSegment]
 askInitialSegments = do
   staticPath <- _routingInfoStaticPath <$> askRI

--- a/src/Reflex/Dom/Contrib/Router.hs
+++ b/src/Reflex/Dom/Contrib/Router.hs
@@ -79,8 +79,6 @@ route
   , PostBuild t m
   , TriggerEvent t m
   , PerformEvent t m
-  , HasJSContext m
-  , HasJSContext (Performable m)
   , MonadJSM m
   , MonadJSM (Performable m))
   => Event t T.Text
@@ -107,8 +105,6 @@ route'
   , PostBuild t m
   , TriggerEvent t m
   , PerformEvent t m
-  , HasJSContext m
-  , HasJSContext (Performable m)
   , MonadJSM m
   , MonadJSM (Performable m)
   , MonadFix m)
@@ -132,8 +128,6 @@ partialPathRoute
   , DomBuilder t m
   , TriggerEvent t m
   , PerformEvent t m
-  , HasJSContext m
-  , HasJSContext (Performable m)
   , MonadJSM m
   , MonadJSM (Performable m)
   , MonadFix m)
@@ -195,17 +189,17 @@ getPopState = do
 
 
 -------------------------------------------------------------------------------
-goForward :: (HasJSContext m, MonadJSM m) => m ()
+goForward :: (MonadJSM m) => m ()
 goForward = withHistory forward
 
 
 -------------------------------------------------------------------------------
-goBack :: (HasJSContext m, MonadJSM m) => m ()
+goBack :: (MonadJSM m) => m ()
 goBack = withHistory back
 
 
 -------------------------------------------------------------------------------
-withHistory :: (HasJSContext m, MonadJSM m) => (History -> m a) -> m a
+withHistory :: (MonadJSM m) => (History -> m a) -> m a
 withHistory act = do
   w <- currentWindowUnchecked
 #if MIN_VERSION_ghcjs_dom(0,8,0)
@@ -219,7 +213,7 @@ withHistory act = do
 
 -------------------------------------------------------------------------------
 -- | (Unsafely) get the 'GHCJS.DOM.Location.Location' of a window
-getLoc :: (HasJSContext m, MonadJSM m) => m Location
+getLoc :: (MonadJSM m) => m Location
 getLoc = do
   win <- currentWindowUnchecked
 #if MIN_VERSION_ghcjs_dom(0,8,0)
@@ -233,7 +227,7 @@ getLoc = do
 
 -------------------------------------------------------------------------------
 -- | (Unsafely) get the URL text of a window
-getUrlText :: (HasJSContext m, MonadJSM m) => m T.Text
+getUrlText :: (MonadJSM m) => m T.Text
 getUrlText = getLoc >>= getHref
 
 
@@ -242,7 +236,7 @@ type URI = U.URIRef U.Absolute
 
 
 -------------------------------------------------------------------------------
-getURI :: (HasJSContext m, MonadJSM m) => m URI
+getURI :: (MonadJSM m) => m URI
 getURI = do
   l <- getUrlText
   return $ either (error "No parse of window location") id .

--- a/src/Reflex/Dom/Contrib/Utils.hs
+++ b/src/Reflex/Dom/Contrib/Utils.hs
@@ -109,6 +109,7 @@ setWindowLoc url = do
 widgetHoldHelper
     :: ( MonadHold t m
        , Adjustable t m
+       , DomBuilder t m
        )
     => (a -> m b)
     -> a


### PR DESCRIPTION
Changed reflex-platform to newest which includes breaking changes in 0.7.0.0 

> Breaking change: Remove HasJSContext and MonadJS. This change also removes the js type parameter from Prerender. Change Prerender js t m to Prerender t m.
Reflex.Dom.WebSocket.Foreign.newWebSocket takes one fewer argument: the first argument used to be a js context

Previous master is no longer compatible with Obelisk projects